### PR TITLE
Update main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"time"
+	"strconv"
 
 	"github.com/gorilla/mux"
 )
@@ -41,7 +42,7 @@ func (b *Block) generateHash() {
 	// get string val of the Data
 	bytes, _ := json.Marshal(b.Data)
 	// concatenate the dataset
-	data := string(b.Pos) + b.Timestamp + string(bytes) + b.PrevHash
+	data := strconv.Itoa(b.Pos) + b.Timestamp + string(bytes) + b.PrevHash
 	hash := sha256.New()
 	hash.Write([]byte(data))
 	b.Hash = hex.EncodeToString(hash.Sum(nil))


### PR DESCRIPTION
To convert int to string use either Sprint or strconv package.  string(b.Pos) returns string of one rune and not string of digits